### PR TITLE
Adding express routing to backend

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,7 @@ import cors, { CorsOptions } from 'cors';
 import path from 'path';
 import fs from 'fs';
 import cameraRouter from './routes/cameraRoutes';
+import gptRouter from './routes/gptRoutes';
 
 // define directory to save images
 const uploadDir = path.join(__dirname, '../__uploads');
@@ -22,6 +23,7 @@ app.use(express.json());
 
 // routes
 app.use('/camera', cameraRouter);
+app.use('/gpt', gptRouter);
 
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));

--- a/server/src/controllers/gptController.ts
+++ b/server/src/controllers/gptController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+import { GptService } from '../services/gptService';
+
+export const GptController = {
+  async ask(req: Request, res: Response) {
+    try {
+      if (!req.body) {
+        return res.status(400).json({ success: false, message: 'Empty body' });
+      }
+
+      let gptService = new GptService();
+      let data = gptService.doSomething();
+
+      res.status(200).json({ success: true, message: 'Reached the backend successfully', data });
+    } catch (err) {
+      if (err instanceof Error) {
+        res.status(500).json({ success: false, message: 'Failed to ask gpt', error: err.message });
+      } else {
+        res
+          .status(500)
+          .json({ success: false, message: 'Failed to ask gpt', error: 'Unknown error' });
+      }
+    }
+  },
+};

--- a/server/src/routes/gptRoutes.ts
+++ b/server/src/routes/gptRoutes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { GptController } from '../controllers/gptController';
+
+const router = express.Router();
+
+router.post('/ask', GptController.ask);
+
+export default router;

--- a/server/src/services/gptService.ts
+++ b/server/src/services/gptService.ts
@@ -1,0 +1,6 @@
+export class GptService {
+  doSomething = () => {
+    console.log('inside the gpt service');
+    return "called gpt"
+  };
+}


### PR DESCRIPTION
## Description

**Fixes # (issue)**
#40 

- introduced new routing GPT in the backend by adding it to the router. 
- Everything related to making chat gpt calls should now be under the gptService.

## Reference 
- reference cameraController.ts, cameraService.ts 

## How To Test?

Do: Make a post request to http://localhost:8080/gpt/ask. 
Expect: Get 200 status with message and data. The server terminal should print "inside the gpt service" 

<img width="851" alt="Screenshot 2024-11-05 at 2 01 30 PM" src="https://github.com/user-attachments/assets/5ef3e517-5876-495d-933f-95daeb1859f6">
<img width="209" alt="Screenshot 2024-11-05 at 2 02 10 PM" src="https://github.com/user-attachments/assets/3b54709c-b239-45ce-ab13-2a7c1b3e4a98">
