### PR TITLE
implemented api routes that calls both camera and gpt service

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import fs from 'fs';
 import cameraRouter from './routes/cameraRoutes';
 import gptRouter from './routes/gptRoutes';
+import apiRouter from './routes/apiRoutes';
 
 // define directory to save images
 const uploadDir = path.join(__dirname, '../__uploads');
@@ -24,6 +25,7 @@ app.use(express.json());
 // routes
 app.use('/camera', cameraRouter);
 app.use('/gpt', gptRouter);
+app.use('/api', apiRouter);
 
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));

--- a/server/src/controllers/apiController.ts
+++ b/server/src/controllers/apiController.ts
@@ -1,0 +1,38 @@
+import { Request, Response } from 'express';
+import { GptService } from '../services/gptService';
+
+export const ApiController = {
+  async process(req: Request, res: Response) {
+    try {
+      if (!req.file) {
+        return res.status(400).json({ success: false, message: 'No file uploaded' });
+      }
+
+      if (req.file.mimetype !== 'image/jpeg') {
+        return res.status(400).json({
+          success: false,
+          message: `Must upload a JPEG image. Your image is minetype: ${req.file.mimetype}`,
+        });
+      }
+
+      console.log('successfully saved the image - creating gpt request');
+
+      let gptService = new GptService();
+      let data = gptService.doSomething();
+
+      res.status(200).json({ success: true, message: 'Successfully processed the api request', data });
+    } catch (err) {
+      if (err instanceof Error) {
+        res
+          .status(500)
+          .json({ success: false, message: 'Failed to process the request', error: err.message });
+      } else {
+        res.status(500).json({
+          success: false,
+          message: 'Failed to process the request',
+          error: 'Unknown error',
+        });
+      }
+    }
+  },
+};

--- a/server/src/routes/apiRoutes.ts
+++ b/server/src/routes/apiRoutes.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+import { ApiController } from '../controllers/apiController';
+
+import { upload } from '../multer';
+
+const router = express.Router();
+
+router.post('/request', upload.single('image'), ApiController.process);
+
+export default router;


### PR DESCRIPTION
## Description

**Fixes # (issue)**
#40 

- introducing new routes that combines camera service and gpt service to aggregate the backend call made by the client

## Issues Faced and Resolutions
Please describe any issues you encountered during development and how you resolved them.

- Issue: initially tried to make calls to cameraController and gptController and use the returned promises to coordinate. 
    - Failed because it was returning multiple jason res
    - Resolution: pivoted to making cameraService and gptService

## How To Test?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

### Testcase 1: Postman testing - success 
Do: 
- Make a post request to http://localhost:8080/api/request with an image file
   - `curl --location 'http://localhost:8080/api/request' \
--form 'image=@"/path/to/file"'`

Expect: 
- [ ] Get 200 status with message and data. 
- [ ] Check the __upload folder and confirm that the photo is uploaded
- [ ] The server terminal should print "inside the gpt service"

<img width="938" alt="Screenshot 2024-11-11 at 3 45 19 PM" src="https://github.com/user-attachments/assets/6399b52c-bf24-491d-9e4a-87c9a5fd5966">

Terminal output
<img width="461" alt="Screenshot 2024-11-11 at 3 36 41 PM" src="https://github.com/user-attachments/assets/254b9fe7-51a1-40cb-9054-077d54e9a95e">

### Testcase 2: Postman testing - fail 
Do: 
- Make a post request to http://localhost:8080/api/request **without** an image file
   - `curl --location --request POST 'http://localhost:8080/api/request'`

Expect: 
- [ ] Get 400 error as shown below
- [ ]  no terminal output as it should not call the gpt service

<img width="928" alt="Screenshot 2024-11-11 at 3 46 28 PM" src="https://github.com/user-attachments/assets/256506a8-8a5d-41eb-8dad-1ff18c22d220">
