### PR TITLE
49 carousel enhancements

### DIFF
--- a/client/components/carousel/carousel.tsx
+++ b/client/components/carousel/carousel.tsx
@@ -16,10 +16,7 @@ const Carousel: React.FC<CarouselProps> = ({ products, onClickOutside }) => {
   const [secondaryLeftIndex, setSecondaryLeftIndex] = useState(1);
   const [secondaryRightIndex, setSecondaryRightIndex] = useState(products.length - 1);
 
-  const carouselContainerRef = useRef<HTMLDivElement | null>(null);
   const carouselRef = useRef<HTMLDivElement | null>(null);
-  const feedbackRef = useRef<HTMLDivElement | null>(null);
-  const sliderRef = useRef<HTMLDivElement | null>(null);
   const movementXRef = useRef(0);
 
   const handleMouseDown = () => {
@@ -82,31 +79,15 @@ const Carousel: React.FC<CarouselProps> = ({ products, onClickOutside }) => {
     };
   }, [grabbing]);
 
-  // Click outside handler
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        carouselContainerRef.current &&
-        !carouselContainerRef.current.contains(event.target as Node) &&
-        carouselRef.current &&
-        !carouselRef.current.contains(event.target as Node) &&
-        feedbackRef.current &&
-        !feedbackRef.current.contains(event.target as Node) &&
-        sliderRef.current &&
-        !sliderRef.current.contains(event.target as Node)
-      ) {
-        onClickOutside(); // Call the handler to exit the carousel
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [onClickOutside]);
-
   return (
-    <div ref={carouselContainerRef} className="flex flex-col items-center gap-7 p-5 w-fit h-fit">
+    <div className="w-full h-full flex flex-col items-center gap-7 p-5">
+      {/* dummy container to handle outside clicks */}
+      <div
+        onClick={() => {
+          onClickOutside();
+        }}
+        className="flex-1 w-full z-[1]"
+      ></div>
       <div
         ref={carouselRef}
         className={`${grabbing ? styles.active : ''} w-full h-[500px] cursor-grab touch-none relative`}
@@ -131,10 +112,10 @@ const Carousel: React.FC<CarouselProps> = ({ products, onClickOutside }) => {
           </div>
         ))}
       </div>
-      <div ref={feedbackRef} className={styles.feedbackCard}>
+      <div className={styles.feedbackCard}>
         <p className="text-xl">{products[primaryIndex].feedback}</p>
       </div>
-      <div ref={sliderRef} className="flex flex-row gap-4">
+      <div className="flex flex-row gap-4">
         {products.map((_, i) => (
           <button
             key={i}

--- a/client/components/carousel/carousel.tsx
+++ b/client/components/carousel/carousel.tsx
@@ -16,8 +16,10 @@ const Carousel: React.FC<CarouselProps> = ({ products, onClickOutside }) => {
   const [secondaryLeftIndex, setSecondaryLeftIndex] = useState(1);
   const [secondaryRightIndex, setSecondaryRightIndex] = useState(products.length - 1);
 
+  const carouselContainerRef = useRef<HTMLDivElement | null>(null);
   const carouselRef = useRef<HTMLDivElement | null>(null);
   const feedbackRef = useRef<HTMLDivElement | null>(null);
+  const sliderRef = useRef<HTMLDivElement | null>(null);
   const movementXRef = useRef(0);
 
   const handleMouseDown = () => {
@@ -38,6 +40,10 @@ const Carousel: React.FC<CarouselProps> = ({ products, onClickOutside }) => {
       setPrimaryIndex((prevIndex) => (prevIndex + 1) % products.length);
     }
     movementXRef.current = 0;
+  };
+
+  const handleSliderClick = (index: number) => {
+    setPrimaryIndex(index);
   };
 
   useEffect(() => {
@@ -80,10 +86,14 @@ const Carousel: React.FC<CarouselProps> = ({ products, onClickOutside }) => {
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
+        carouselContainerRef.current &&
+        !carouselContainerRef.current.contains(event.target as Node) &&
         carouselRef.current &&
         !carouselRef.current.contains(event.target as Node) &&
         feedbackRef.current &&
-        !feedbackRef.current.contains(event.target as Node)
+        !feedbackRef.current.contains(event.target as Node) &&
+        sliderRef.current &&
+        !sliderRef.current.contains(event.target as Node)
       ) {
         onClickOutside(); // Call the handler to exit the carousel
       }
@@ -96,7 +106,7 @@ const Carousel: React.FC<CarouselProps> = ({ products, onClickOutside }) => {
   }, [onClickOutside]);
 
   return (
-    <div className="flex flex-col items-center gap-7 p-5">
+    <div ref={carouselContainerRef} className="flex flex-col items-center gap-7 p-5 w-fit h-fit">
       <div
         ref={carouselRef}
         className={`${grabbing ? styles.active : ''} w-full h-[500px] cursor-grab touch-none relative`}
@@ -123,6 +133,15 @@ const Carousel: React.FC<CarouselProps> = ({ products, onClickOutside }) => {
       </div>
       <div ref={feedbackRef} className={styles.feedbackCard}>
         <p className="text-xl">{products[primaryIndex].feedback}</p>
+      </div>
+      <div ref={sliderRef} className="flex flex-row gap-4">
+        {products.map((_, i) => (
+          <button
+            key={i}
+            onClick={() => handleSliderClick(i)}
+            className={`${styles.sliderThumb} ${i === primaryIndex ? styles.sliderThumbFocus : styles.sliderThumbUnFocus}`}
+          ></button>
+        ))}
       </div>
     </div>
   );

--- a/client/components/carousel/style.module.css
+++ b/client/components/carousel/style.module.css
@@ -87,14 +87,14 @@
 }
 
 .sliderThumb {
-  background-color: rgba(120, 113, 108, 0.9);
+  background-color: #fff;
   z-index: 1;
 
   @apply w-[18px] h-[18px] rounded-full transition-opacity ease-in-out;
 }
 
 .sliderThumbUnFocus {
-  opacity: 0.7;
+  opacity: 0.5;
 }
 
 .sliderThumbFocus {

--- a/client/components/carousel/style.module.css
+++ b/client/components/carousel/style.module.css
@@ -85,3 +85,18 @@
   z-index: 1;
   @apply w-[80%] p-4 rounded-xl shadow-md touch-none;
 }
+
+.sliderThumb {
+  background-color: rgba(120, 113, 108, 0.9);
+  z-index: 1;
+
+  @apply w-[18px] h-[18px] rounded-full transition-opacity ease-in-out;
+}
+
+.sliderThumbUnFocus {
+  opacity: 0.7;
+}
+
+.sliderThumbFocus {
+  opacity: 1;
+}


### PR DESCRIPTION
## Description

**Fixes #49 **

- adding clickable slide indicators
- better handling for outside click using a dummy container

## How To Test?

1. run the client and server
2. you should see the following along with the carousel
  - [ ] slide indicators
  - [ ] the slide you are currently on should be highlighted, others are slightly transparent
  - [ ] clicking one of the indicators should move you to that slide
  - [ ] swiping actions will highlight the indicator for the slide you are moving to

## Screenshots (if applicable):

![image](https://github.com/user-attachments/assets/026e6108-b724-47f8-9940-9816135ae3e2)

