### PR TITLE
71 fixing flake8 compatibility with black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,4 @@
 [flake8]
 max-line-length = 120
+extend-select = B950
+extend-ignore = E203,E501,E701

--- a/database/README.md
+++ b/database/README.md
@@ -58,7 +58,7 @@ Updating the conda environment,
 
 ```bash
 cd database
-conda env update --file environment.yml --prun
+conda env update --file environment.yml --prune
 ```
 
 If you've installed new packages and want to update the environment.yml file,

--- a/database/environment.yml
+++ b/database/environment.yml
@@ -1,6 +1,7 @@
 name: scraper  # name of environemnt
 channels:
   - defaults
+  - conda-forge
 dependencies:
   - python=3.12
   - pandas
@@ -8,3 +9,4 @@ dependencies:
   - black
   - flake8
   - python-dotenv
+  - flake8-bugbear

--- a/database/src/scraper.py
+++ b/database/src/scraper.py
@@ -165,7 +165,10 @@ class Scraper:
         logging.error("Max retries exceeded. Unable to complete the request.")
         return None
 
-    def save_df(self, df, output_file=os.path.join(os.getcwd(), "data", "output.csv")):
+    def save_df(self, df, output_file=None):
+        if output_file is None:
+            output_file = os.path.join(os.getcwd(), "data", "output.csv")
+
         df.to_csv(output_file, index=False)
         print(f"DataFrame saved to {output_file}")
 
@@ -226,3 +229,10 @@ class Scraper:
                 print("Error during json parse", Exception)
         else:
             print("Error with refresh", response.status_code)
+
+    def testing():
+        batch_size = 2
+        my_lst = list(range(0, 100))
+        for i in range(0, len(my_lst)):
+            numbers = my_lst[i : i + batch_size]
+            print(numbers)

--- a/database/src/scraper.py
+++ b/database/src/scraper.py
@@ -229,10 +229,3 @@ class Scraper:
                 print("Error during json parse", Exception)
         else:
             print("Error with refresh", response.status_code)
-
-    def testing():
-        batch_size = 2
-        my_lst = list(range(0, 100))
-        for i in range(0, len(my_lst)):
-            numbers = my_lst[i : i + batch_size]
-            print(numbers)


### PR DESCRIPTION
## Description

**Fixes #71 **

Some rules in black don't align with flake8. Example, rule E203,
![image](https://github.com/user-attachments/assets/4142bc67-4f2e-435e-9628-28726267e4bb)

Installing [bugbear plugin](https://anaconda.org/conda-forge/flake8-bugbear) to use with flake8 and using recommended flake8 config.

## Documentation Used

Please list any documentation or resources that were referenced while making these changes.

- [Using Black with other tools](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8)
- [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear?tab=readme-ov-file#installation)

## How To Test?

- hopefully less linting conflicts between black and flake8
- bypasses E203 warning, you may notice other linting issues in the code!
