### PR TITLE
94 local development fixes

### DIFF
--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -62,10 +62,3 @@ jobs:
           subject-name: index.docker.io/natapoke/capstone
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-
-      - name: Deploy to Azure App Service
-        uses: azure/webapps-deploy@v2
-        with:
-          app-name: 'ai-fashion-mirror-server'
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-          images: 'natapoke/capstone:server-prod'

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -9,16 +9,11 @@
 
 name: Publish Docker image
 
+# only run on push to main branch
 on:
   push:
-    # trigger on pull requests
-    pull_request:
-      branches: 
-        - main
-      path:
-        - .github/workflows/publish-server.yml
-        - server/**
-    # only trigger build for specific paths
+    branches:
+      - main
     paths:
       - .github/workflows/publish-server.yml
       - server/**

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -2,8 +2,6 @@
 const dotenv = require('dotenv');
 const path = require('path');
 
-console.log(process.env.NODE_ENV);
-
 if (process.env.NODE_ENV === 'development') {
   dotenv.config({
     path: path.resolve(__dirname, '../.env'), // Load the .env from root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,5 @@
 services:
-  # client:
-  #   build:
-  #     context: .
-  #     dockerfile: ./client/Dockerfile
-  #   ports:
-  #     - 127.0.0.1:3000:3000
-  #   env_file:
-  #     - .env
-  #   networks:
-  #     - ai-fasion-mirror
-  #   volumes:
-  #     - ./client:/app
-  #     - /app/node_modules
-
-  # running client on localhost with https
-  # server:
-  #   build:
-  #     context: .
-  #     dockerfile: ./server/Dockerfile
-  #   ports:
-  #     - 127.0.0.1:8080:8080
-  #   # devices:
-  #   #   - /dev/video0:/dev/video0
-  #   env_file:
-  #     - .env
-  #   networks:
-  #     - ai-fasion-mirror
-
-  # note: no solution for hot reloading nextjs in docker
+  # note: does not hot reload T_T
   client-local:
     build:
       context: .
@@ -36,7 +8,6 @@ services:
       - 3000:3000
     env_file:
       - .env
-      - .env.local
     volumes:
       - ./client/pages:/app/pages
       - ./client/components:/app/components
@@ -52,35 +23,5 @@ services:
       - 8000:8000
     env_file:
       - .env
-      - .env.local
     volumes:
       - ./server/src:/app/src
-
-  server-prod:
-    build:
-      context: ./server
-      dockerfile: Dockerfile.prod
-    ports:
-      - 8081:8000
-    env_file:
-      - .env.production
-    volumes:
-      - ./server/src:/app/src
-
-  client-prod:
-    build:
-      context: ./client
-      dockerfile: Dockerfile.prod
-    ports:
-      - 3001:3000
-    env_file:
-      - .env.production
-    environment:
-      - NEXT_PUBLIC_SERVER_BASE_URL=$NEXT_PUBLIC_SERVER_BASE_URL
-    volumes:
-      - ./client/pages:/app/pages
-      - ./client/components:/app/components
-      - ./client/services:/app/services
-
-networks:
-  ai-fasion-mirror:

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -57,7 +57,7 @@ const io = new Server(server, {
 new SocketManager(io);
 
 const PORT = (process.env.SERVER_PORT as unknown as number) || 8000;
-server.listen(PORT, '0.0.0.0', () => {
+server.listen(PORT, () => {
   const address = server.address();
   const host = typeof address === 'string' ? address : address?.address;
   const port = typeof address === 'string' ? PORT : address?.port;

--- a/server/src/sockets/SocketManager.ts
+++ b/server/src/sockets/SocketManager.ts
@@ -18,7 +18,6 @@ export class SocketManager {
   }
 
   initSocketEvents() {
-    console.log('initSocketEvent');
     this.io.on('connection', (socket: Socket) => {
       console.log(`Socket ${socket.id} connected.`);
 


### PR DESCRIPTION
## Description

**Fixes #94 **

**Local Development**

When running locally, also make sure that you have the `.env` file

Make sure to generate certs for _localhost_
```
cd ssl
mkcert -key-file localhost-key.pem -cert-file localhost.pem localhost
```
These certs will be used by the docker images to ensure the server can run on https locally

Once certs are generated, you can run this command, which will build containers for the client and server.
```
docker compose up --build
```

Please note that clicking the Port cell in Docker Desktop, will not take you to the correct URL, because it forwards to HTTP and not HTTPS
![image](https://github.com/user-attachments/assets/78dc1b1d-05d8-40b9-85e8-a3a94b086e2e)



**Production Development**

Pushes to _main_ will automatically trigger new deployments on render and vercel

The client is deployed on vercel, [https://ai-fashion-mirror.vercel.app/](https://ai-fashion-mirror.vercel.app/).
The server is deployed on render, [https://ai-fashion-mirror.onrender.com](https://ai-fashion-mirror.onrender.com)

